### PR TITLE
feat: update to minidumper 0.9 / thiserror 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ version = "0.2.2"
 
 [dependencies]
 crash-handler = "0.6"
-minidumper = "0.8"
-thiserror = "1"
+minidumper = "0.9"
+thiserror = "2"
 uuid = {version = "1", features = ["v4"]}
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ pub fn start(
 
     // Loop until we have a client or return error if connect_timeout is reached
     let client = loop {
-        match minidumper::Client::with_name(socket_name).map(Arc::new) {
+        match minidumper::Client::with_name(crate::to_socket_name(socket_name)).map(Arc::new) {
             Ok(client) => break client,
             Err(e) => {
                 if wait_time < connect_timeout {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,17 @@ impl MinidumperChild {
     }
 }
 
+pub(crate) fn to_socket_name(s: &str) -> minidumper::SocketName<'_> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        minidumper::SocketName::Abstract(s)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        minidumper::SocketName::Path(std::path::Path::new(s))
+    }
+}
+
 pub fn make_socket_name(session_id: uuid::Uuid) -> String {
     if cfg!(any(target_os = "linux", target_os = "android")) {
         format!("temp-socket-{}", session_id.simple())

--- a/src/server.rs
+++ b/src/server.rs
@@ -99,7 +99,7 @@ where
     Minidump: Fn(Vec<u8>, &Path) + Send + Sync + 'static,
     Message: Fn(u32, Vec<u8>) + Send + Sync + 'static,
 {
-    Server::with_name(socket_name)
+    Server::with_name(crate::to_socket_name(socket_name))
         .map_err(Error::from)
         .and_then(|mut server| {
             let handler = Box::new(Handler::new(crashes_dir, on_minidump, on_message));


### PR DESCRIPTION
minidumper 0.9 made SocketName public and removed the From<&str> impl on Client::with_name / Server::with_name. Add a small to_socket_name helper that constructs the right variant per target_os, matching the existing make_socket_name conventions (abstract namespace on Linux/Android, filesystem path elsewhere).

minidumper 0.9 transitively bumps minidump-writer to 0.11, which includes the MemReader-based stack reader that handles partial reads across unmapped guard pages gracefully (fixes a class of EIO failures seen in 0.8 when dumping processes with idle threads).